### PR TITLE
background thread pool for page compression+upsertion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,11 +32,11 @@ set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-add_library(nested_vfs SHARED src/nested_vfs.cc src/SQLiteNestedVFS.h src/SQLiteVFS.h)
+add_library(nested_vfs SHARED src/nested_vfs.cc src/SQLiteNestedVFS.h src/SQLiteVFS.h src/ThreadPool.h)
 SET_TARGET_PROPERTIES(nested_vfs PROPERTIES PREFIX "")
 target_link_libraries(nested_vfs PRIVATE SQLiteCpp)
 
-add_library(zstd_vfs SHARED src/zstd_vfs.cc src/SQLiteNestedVFS.h src/SQLiteVFS.h src/zstd_vfs.h)
+add_library(zstd_vfs SHARED src/zstd_vfs.cc src/SQLiteNestedVFS.h src/SQLiteVFS.h src/zstd_vfs.h src/ThreadPool.h)
 SET_TARGET_PROPERTIES(zstd_vfs PROPERTIES PREFIX "")
 target_link_libraries(zstd_vfs PRIVATE SQLiteCpp zstd)
 
@@ -49,7 +49,7 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
     FetchContent_MakeAvailable(catch)
     include_directories(${catch_SOURCE_DIR}/single_include)
 
-    add_executable(test_exe test/test.cc test/test_vfstrace.c src/SQLiteNestedVFS.h src/SQLiteVFS.h)
+    add_executable(test_exe test/test.cc test/test_vfstrace.c src/SQLiteNestedVFS.h src/SQLiteVFS.h src/ThreadPool.h)
     target_link_libraries(test_exe PRIVATE SQLiteCpp)
 
     include(CTest)

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Some parameters are controlled from the file URI's query string opening the data
 | writing/compression | <ul><li>level</li><li>outer_page_size</li><li>outer_unsafe</li></ul> | <ul><li>page_size</li><li>auto_vacuum</li><li>journal_mode</li></ul> |
 | reading/decompression | <ul><li>outer_cache_size</li></ul> | <ul><li>cache_size</li></ul> |
 
-* **&level=3**: Zstandard compression level for newly written pages (-5 to 22)
+* **&level=3**: Zstandard compression level for newly written pages (-7 to 22)
 * **&outer_page_size=4096**: page size for the newly-created outer database; suggest doubling the (inner) page_size, to reduce space overhead from packing the compressed inner pages
 * **&outer_unsafe=false**: set true to speed up bulk load by disabling transaction safety for outer database (app crash easily causes corruption)
 

--- a/README.md
+++ b/README.md
@@ -114,10 +114,11 @@ Some parameters are controlled from the file URI's query string opening the data
 
 |   | URI query parameters | PRAGMA |
 | -- | -- | -- |
-| writing/compression | <ul><li>level</li><li>outer_page_size</li><li>outer_unsafe</li></ul> | <ul><li>page_size</li><li>auto_vacuum</li><li>journal_mode</li></ul> |
+| writing/compression | <ul><li>level</li><li>threads</li><li>outer_page_size</li><li>outer_unsafe</li></ul> | <ul><li>page_size</li><li>auto_vacuum</li><li>journal_mode</li></ul> |
 | reading/decompression | <ul><li>outer_cache_size</li></ul> | <ul><li>cache_size</li></ul> |
 
 * **&level=3**: Zstandard compression level for newly written pages (-7 to 22)
+* **&threads=1**: background compression threads (negative: match available hardware)
 * **&outer_page_size=4096**: page size for the newly-created outer database; suggest doubling the (inner) page_size, to reduce space overhead from packing the compressed inner pages
 * **&outer_unsafe=false**: set true to speed up bulk load by disabling transaction safety for outer database (app crash easily causes corruption)
 

--- a/src/ThreadPool.h
+++ b/src/ThreadPool.h
@@ -1,9 +1,12 @@
 // Worker thread pool:
-//  (i) Each job has one parallel and one serialized stage. The serialized stages run on a worker
-//      thread in the order of the jobs' original queueing.
-//  (ii) no return values, only side-effects (except: result of parallel stage is passed to serial
-//       stage)
-//  (iii) enqueue operation blocks if queue is 'full'
+// 1. Each job has one stage that can run in parallel, followed by a serial stage to run
+//    exclusively of other jobs' serial stages in the enqueued order. Put another way, the data
+//    flows through a parallel scatter and serial gather.
+// 2. The jobs have no return values, relying instead on side-effects. (Exception: for each job,
+//    the parallel stage result passes a result to its serialized stage.)
+// 3. The Enqueue operation blocks if the queue is "full"
+
+#pragma once
 
 #include <atomic>
 #include <climits>
@@ -13,34 +16,40 @@
 #include <queue>
 #include <thread>
 
+namespace SQLiteNested {
+
 class ThreadPool {
     struct Job {
+        // sequence number used to ensure serial stages run in the correct order
         unsigned long long seqno = ULLONG_MAX;
         void *x = nullptr;
-        std::function<void *(void *)> par;
-        std::function<void(void *)> ser;
+        std::function<void *(void *) noexcept> par;
+        std::function<void(void *) noexcept> ser;
     };
 
+    // main thread state
     size_t max_threads_, max_jobs_;
     std::vector<std::thread> threads_;
-    unsigned long long seqno_next_ = 0;
-    std::atomic<unsigned long long> seqno_done_;
+    unsigned long long seqno_next_ = 0; // jobs enqueued so far / next seqno to be enqueued
 
+    // shared state
+    std::atomic<unsigned long long> seqno_done_; // highest seqno done (serial stage completed)
     std::mutex state_mutex_;
     std::condition_variable cv_enqueue_, cv_done_;
     std::queue<Job> par_queue_;
     bool shutdown_ = false;
 
+    // serial-stage state: priority queue to order jobs by seqno
     std::mutex ser_mutex_;
-    std::function<bool(const Job &, const Job &)> job_greater = [](const Job &lhs, const Job &rhs) {
-        return lhs.seqno > rhs.seqno;
-    };
-    std::priority_queue<Job, std::vector<Job>, decltype(job_greater)> ser_queue_;
+    std::function<bool(const Job &, const Job &)> job_greater_ =
+        [](const Job &lhs, const Job &rhs) { return lhs.seqno > rhs.seqno; };
+    std::priority_queue<Job, std::vector<Job>, decltype(job_greater_)> ser_queue_;
 
+    // worker thread
     void Worker() {
         std::unique_lock<std::mutex> lock(state_mutex_);
         while (true) {
-            // wait for job
+            // wait for / dequeue a job
             while (!shutdown_ && par_queue_.empty()) {
                 cv_enqueue_.wait(lock);
             }
@@ -49,26 +58,26 @@ class ThreadPool {
             }
             Job job = par_queue_.front();
             par_queue_.pop();
-            lock.release();
+            lock.unlock();
             // run parallel stage
             if (job.par) {
                 job.x = job.par(job.x);
             }
             {
-                std::lock_guard<std::mutex> ser_lock(ser_mutex_);
                 // enqueue serial stage
+                std::lock_guard<std::mutex> ser_lock(ser_mutex_);
                 ser_queue_.push(job);
-                // run the available, contiguous sequence of serial stage(s), if any; possibly but
-                // not necessarily including that of the job whose parallel stage we just ran
+                // run the enqueued serial stage(s) so long as the next one is in seqno order.
+                // this may or may not include the one just enqueued.
                 while (!ser_queue_.empty()) {
                     job = ser_queue_.top();
                     if (job.seqno != seqno_done_) {
                         break;
                     }
+                    ser_queue_.pop();
                     if (job.ser) {
                         job.ser(job.x);
                     }
-                    ser_queue_.pop();
                     ++seqno_done_;
                 }
             }
@@ -79,7 +88,7 @@ class ThreadPool {
 
   public:
     ThreadPool(size_t max_threads, size_t max_jobs)
-        : max_threads_(max_threads), max_jobs_(max_jobs) {
+        : max_threads_(max_threads), max_jobs_(max_jobs), ser_queue_(job_greater_) {
         seqno_done_ = 0;
     }
     ~ThreadPool() {
@@ -93,7 +102,9 @@ class ThreadPool {
         }
     }
 
-    void Enqueue(void *x, std::function<void *(void *)> par, std::function<void(void *)> ser) {
+    // Enqueue ser(par(x)) for background processing as described. The functions must not raise.
+    void Enqueue(void *x, std::function<void *(void *) noexcept> par,
+                 std::function<void(void *) noexcept> ser) {
         std::unique_lock<std::mutex> lock(state_mutex_);
         while (seqno_next_ - seqno_done_ >= max_jobs_) {
             cv_done_.wait(lock);
@@ -111,7 +122,8 @@ class ThreadPool {
         cv_enqueue_.notify_one();
     }
 
-    void Drain() {
+    // Await completion of all previously enqueued jobs
+    void Barrier() {
         if (seqno_next_) {
             std::unique_lock<std::mutex> lock(state_mutex_);
             while (seqno_done_ < seqno_next_) {
@@ -120,3 +132,5 @@ class ThreadPool {
         }
     }
 };
+
+} // namespace SQLiteNested

--- a/src/ThreadPool.h
+++ b/src/ThreadPool.h
@@ -1,0 +1,122 @@
+// Worker thread pool:
+//  (i) Each job has one parallel and one serialized stage. The serialized stages run on a worker
+//      thread in the order of the jobs' original queueing.
+//  (ii) no return values, only side-effects (except: result of parallel stage is passed to serial
+//       stage)
+//  (iii) enqueue operation blocks if queue is 'full'
+
+#include <atomic>
+#include <climits>
+#include <condition_variable>
+#include <functional>
+#include <mutex>
+#include <queue>
+#include <thread>
+
+class ThreadPool {
+    struct Job {
+        unsigned long long seqno = ULLONG_MAX;
+        void *x = nullptr;
+        std::function<void *(void *)> par;
+        std::function<void(void *)> ser;
+    };
+
+    size_t max_threads_, max_jobs_;
+    std::vector<std::thread> threads_;
+    unsigned long long seqno_next_ = 0;
+    std::atomic<unsigned long long> seqno_done_;
+
+    std::mutex state_mutex_;
+    std::condition_variable cv_enqueue_, cv_done_;
+    std::queue<Job> par_queue_;
+    bool shutdown_ = false;
+
+    std::mutex ser_mutex_;
+    std::function<bool(const Job &, const Job &)> job_greater = [](const Job &lhs, const Job &rhs) {
+        return lhs.seqno > rhs.seqno;
+    };
+    std::priority_queue<Job, std::vector<Job>, decltype(job_greater)> ser_queue_;
+
+    void Worker() {
+        std::unique_lock<std::mutex> lock(state_mutex_);
+        while (true) {
+            // wait for job
+            while (!shutdown_ && par_queue_.empty()) {
+                cv_enqueue_.wait(lock);
+            }
+            if (shutdown_) {
+                break;
+            }
+            Job job = par_queue_.front();
+            par_queue_.pop();
+            lock.release();
+            // run parallel stage
+            if (job.par) {
+                job.x = job.par(job.x);
+            }
+            {
+                std::lock_guard<std::mutex> ser_lock(ser_mutex_);
+                // enqueue serial stage
+                ser_queue_.push(job);
+                // run the available, contiguous sequence of serial stage(s), if any; possibly but
+                // not necessarily including that of the job whose parallel stage we just ran
+                while (!ser_queue_.empty()) {
+                    job = ser_queue_.top();
+                    if (job.seqno != seqno_done_) {
+                        break;
+                    }
+                    if (job.ser) {
+                        job.ser(job.x);
+                    }
+                    ser_queue_.pop();
+                    ++seqno_done_;
+                }
+            }
+            lock.lock();
+            cv_done_.notify_all();
+        }
+    }
+
+  public:
+    ThreadPool(size_t max_threads, size_t max_jobs)
+        : max_threads_(max_threads), max_jobs_(max_jobs) {
+        seqno_done_ = 0;
+    }
+    ~ThreadPool() {
+        {
+            std::lock_guard<std::mutex> lock(state_mutex_);
+            shutdown_ = true;
+        }
+        cv_enqueue_.notify_all();
+        for (auto &thread : threads_) {
+            thread.join();
+        }
+    }
+
+    void Enqueue(void *x, std::function<void *(void *)> par, std::function<void(void *)> ser) {
+        std::unique_lock<std::mutex> lock(state_mutex_);
+        while (seqno_next_ - seqno_done_ >= max_jobs_) {
+            cv_done_.wait(lock);
+        }
+        Job job;
+        job.seqno = seqno_next_++;
+        job.x = x;
+        job.par = par;
+        job.ser = ser;
+        par_queue_.push(job);
+        if (threads_.size() < max_threads_ && threads_.size() < par_queue_.size()) {
+            threads_.emplace_back([this]() { this->Worker(); });
+        }
+        lock.unlock();
+        cv_enqueue_.notify_one();
+    }
+
+    void Drain() {
+        if (seqno_next_) {
+            std::unique_lock<std::mutex> lock(state_mutex_);
+            while (seqno_done_ < seqno_next_) {
+                cv_done_.wait(lock);
+            }
+        }
+    }
+};

--- a/src/ThreadPool.h
+++ b/src/ThreadPool.h
@@ -1,9 +1,9 @@
 // Worker thread pool:
-// 1. Each job has one stage that can run in parallel, followed by a serial stage to run
-//    exclusively of other jobs' serial stages in the enqueued order. Put another way, the data
-//    flows through a parallel scatter and serial gather.
+// 1. Each job has one stage that can run in parallel, followed by a serial stage to be run in the
+//    enqueued order, exclusively of other jobs' serial stages. Put another way, the data flow
+//    through a parallel scatter, then a serial gather.
 // 2. The jobs have no return values, relying instead on side-effects. (Exception: for each job,
-//    the parallel stage result passes a result to its serialized stage.)
+//    the parallel stage passes a void* to its serialized stage.)
 // 3. The Enqueue operation blocks if the queue is "full"
 
 #pragma once
@@ -102,7 +102,7 @@ class ThreadPool {
         }
     }
 
-    // Enqueue ser(par(x)) for background processing as described. The functions must not raise.
+    // Enqueue ser(par(x)) for background processing as described. The functions must not throw.
     void Enqueue(void *x, std::function<void *(void *) noexcept> par,
                  std::function<void(void *) noexcept> ser) {
         std::unique_lock<std::mutex> lock(state_mutex_);

--- a/test/TPC-H.py
+++ b/test/TPC-H.py
@@ -126,7 +126,7 @@ def run(cache_MiB, level, inner_page_KiB, outer_page_KiB):
     with timer(timings, "load_zstd"):
         con.execute(f"PRAGMA page_size={1024*inner_page_KiB}")
         con.execute(
-            f"VACUUM INTO 'file:/tmp/TPC-H.zstd.db?vfs=zstd&outer_unsafe=true&outer_page_size={1024*outer_page_KiB}&level={level}'"
+            f"VACUUM INTO 'file:/tmp/TPC-H.zstd.db?vfs=zstd&outer_unsafe=true&outer_page_size={1024*outer_page_KiB}&level={level}&threads=-1'"
         )
         con.close()
     timings["db_size"] = os.path.getsize("/tmp/TPC-H.vacuum.db")

--- a/test/test.cc
+++ b/test/test.cc
@@ -145,7 +145,7 @@ TEST_CASE("cellular_automata") {
     {
         SQLite::Database control(testdir + "/control",
                                  SQLite::OPEN_READWRITE | SQLite::OPEN_CREATE);
-        SQLite::Database experiment("file:" + testdir + "/experiment?vfs=nested",
+        SQLite::Database experiment("file:" + testdir + "/experiment?vfs=nested&threads=-1",
                                     SQLite::OPEN_READWRITE | SQLite::OPEN_CREATE |
                                         SQLite::OPEN_URI);
 


### PR DESCRIPTION
Page compression and upsertion into the 'outer' database run on a background thread pool, usually without blocking the writer. If we get a page-read or other request while such background operations are outstanding, wait for them to complete before proceeding.